### PR TITLE
Update network-environment.yaml

### DIFF
--- a/RDU-Scale/Newton/R730xd/network-environment.yaml
+++ b/RDU-Scale/Newton/R730xd/network-environment.yaml
@@ -1,8 +1,8 @@
 resource_registry:
-  OS::TripleO::BlockStorage::Net::SoftwareConfig: /home/stack/templates/nic-configs/cinder-storage.yaml
+  #OS::TripleO::BlockStorage::Net::SoftwareConfig: /home/stack/templates/nic-configs/cinder-storage.yaml
   #OS::TripleO::Compute::Net::SoftwareConfig: /home/stack/templates/nic-configs/r730-compute.yaml
   OS::TripleO::Controller::Net::SoftwareConfig: /home/stack/templates/nic-configs/r730-controller.yaml
-  OS::TripleO::ObjectStorage::Net::SoftwareConfig: /home/stack/templates/nic-configs/swift-storage.yaml
+  #OS::TripleO::ObjectStorage::Net::SoftwareConfig: /home/stack/templates/nic-configs/swift-storage.yaml
   OS::TripleO::R730CephStorage::Net::SoftwareConfig: /home/stack/templates/nic-configs/r730ceph-storage.yaml
   OS::TripleO::R730Compute::Net::SoftwareConfig: /home/stack/templates/nic-configs/r730-compute.yaml
   OS::TripleO::R730Compute::Ports::ExternalPort: /usr/share/openstack-tripleo-heat-templates/network/ports/noop.yaml


### PR DESCRIPTION
- nic-configs/cinder-storage.yaml and nic-configs/swift-storage.yaml are not in openstack-templates/RDU-Scale/Newton/R730xd/ 
- Not having these files causes the deployment to fail
- As a workaround I comment them out as shown here
- Deleting them might be better but I am keeping those lines in case you want to add those files and undo this workaround