### PR TITLE
R730xd p6p{1,2} to p4p{1,2} change AND add R730xdHciDpdk

### DIFF
--- a/RDU-Scale/Newton/R730xd/README.md
+++ b/RDU-Scale/Newton/R730xd/README.md
@@ -20,7 +20,7 @@ in the undercloud.conf when deploying the undercloud.
 ## Hardware Details
 
 Each of the R730xd node contains 4 NICs that can be used for an Overcloud
-deployment: em1, em2, p6p1 and p6p2. All these NICs are 10G. We will make use of
+deployment: em1, em2, p4p1 and p4p2. All these NICs are 10G. We will make use of
 all the four NICs in our templates. Tenant, Internal API and Storage ( along
 with Storage Management in the case of controllers) are all each seperated out
 onto a different NIC. Note that we will still be using OVS brdiges in some cases

--- a/RDU-Scale/Newton/R730xd/nic-configs/README.md
+++ b/RDU-Scale/Newton/R730xd/nic-configs/README.md
@@ -12,18 +12,18 @@ The R730xds have 4 interfaces attached, our templates will deploy the following 
 |   Bridge   |  Interface     |   Networks                         |
 |------------|:--------------:|-----------------------------------:|
 | br-storage | em1            | StorageNetwork, StorageMgmtNetwork |
-| br-tenant  | p6p1           | TenantNetwork                      |
+| br-tenant  | p4p1           | TenantNetwork                      |
 | br-ex      | em2            | ControlPlane, ExternalNetwork      |                       
-|            | p6p2           | InternalAPISubnet                  |
+|            | p4p2           | InternalAPISubnet                  |
 
 #### Compute
 
 |   Bridge   |  Interface     |   Networks        |
 |------------|:--------------:|------------------:|
 | br-storage | em1            | StorageNetwork    |
-| br-tenant  | p6p1           | TenantNetwork     |
+| br-tenant  | p4p1           | TenantNetwork     |
 | br-ex      | em2            | ControlPlane      |
-|            | p6p2           | InternalAPISubnet |
+|            | p4p2           | InternalAPISubnet |
 
 #### Ceph
 

--- a/RDU-Scale/Newton/R730xd/nic-configs/r730-compute.yaml
+++ b/RDU-Scale/Newton/R730xd/nic-configs/r730-compute.yaml
@@ -100,7 +100,7 @@ resources:
               members:
                 -
                   type: interface
-                  name: p6p1
+                  name: p4p1
                   primary: true
                 -
                   type: vlan
@@ -135,7 +135,7 @@ resources:
                 
             -
               type: interface
-              name: p6p2
+              name: p4p2
               use_dhcp: false
               addresses:
                 -

--- a/RDU-Scale/Newton/R730xd/nic-configs/r730-controller.yaml
+++ b/RDU-Scale/Newton/R730xd/nic-configs/r730-controller.yaml
@@ -114,7 +114,7 @@ resources:
               members:
                 -
                   type: interface
-                  name: p6p1
+                  name: p4p1
                   primary: true
                 -
                   type: vlan
@@ -160,7 +160,7 @@ resources:
                 
             -
               type: interface
-              name: p6p2
+              name: p4p2
               use_dhcp: false
               addresses:
                 -

--- a/RDU-Scale/Newton/R730xdHciDpdk/README.md
+++ b/RDU-Scale/Newton/R730xdHciDpdk/README.md
@@ -1,0 +1,133 @@
+Heat Templates for HCI/DPDK Overcloud with R730XD Nodes
+=======================================================
+
+These templates can be used for deploying an overcloud with the
+following command (see also [deploy.sh](deploy.sh)).
+
+```
+openstack overcloud deploy --templates \
+  -r ~/custom-templates/custom-roles.yaml \
+  -e /usr/share/openstack-tripleo-heat-templates/environments/network-isolation.yaml \
+  -e /usr/share/openstack-tripleo-heat-templates/environments/puppet-pacemaker.yaml \
+  -e /usr/share/openstack-tripleo-heat-templates/environments/storage-environment.yaml \
+  -e ~/custom-templates/network.yaml \
+  -e ~/custom-templates/ceph.yaml \
+  -e ~/custom-templates/nova.yaml \
+  -e ~/custom-templates/dpdk.yaml \
+  -e ~/custom-templates/layout.yaml 
+```
+
+It is assumed that the command is executed from `/home/stack` and the
+configuration files in this directory are all present in
+`/home/stack/custom-templates` on the undercloud.
+
+These templates were used with an undercloud which was deployed using [ops-tools](https://github.com/redhat-performance/ops-tools/tree/master/ansible/undercloud) with [hosts](undercloud/hosts) and [vars/main.yml](undercloud/vars/main.yml) added to set `local_interface = em2`.
+
+Ironic
+------
+
+Ironic Metadata Disk Cleaning was used instead of a first-boot zap
+disk. This was not via TripleO's "clean_nodes=True" param but purely a
+change in Ironic. 
+
+Identify the neutron UUID of the TripleO ctlplane:
+
+```
+[stack@c10-h01-r730xd ~]$ neutron net-list
++--------------------------------------+----------+----------------------------------------+
+| id                                   | name     | subnets                                |
++--------------------------------------+----------+----------------------------------------+
+| 40a26da2-bcc6-47c9-b308-49c8d6911f8d | ctlplane | 5541d13e-3d44-442b-b2c3-1c99bc959861   |
+|                                      |          | 192.0.2.0/24                           |
++--------------------------------------+----------+----------------------------------------+
+[stack@c10-h01-r730xd ~]$ 
+```
+Modify ironic.conf:
+```
+    [conductor]
+    automated_clean = True
+    [deploy]
+    erase_devices_priority = 0
+    erase_devices_metadata_priority = 10
+    [neutron]
+    cleaning_network_uuid = $UUID
+```
+For example:
+```
+[root@c10-h01-r730xd ironic]# egrep "clean|erase" /etc/ironic/ironic.conf | egrep -v \#
+automated_clean = True
+erase_devices_priority = 0
+erase_devices_metadata_priority = 10
+cleaning_network_uuid = 40a26da2-bcc6-47c9-b308-49c8d6911f8d
+[root@c10-h01-r730xd ironic]# 
+```
+Bounce the ironic conductor service.
+```
+systemctl restart openstack-ironic-conductor.service
+```
+Once that's done, merely trying to put the nodes into the ironic state
+"available" will put them in the "cleaning" state first and then clean
+the disks before they finally get set to the "available" state. I set
+the state on my nodes out of available and back with the following:
+
+```
+for ironic_id in $(ironic node-list | awk {'print $2'} | grep -v UUID | egrep -v '^$'); do
+     ironic node-set-provision-state $ironic_id manage; 
+done 
+
+for ironic_id in $(ironic node-list | awk {'print $2'} | grep -v UUID | egrep -v '^$'); do 
+     ironic node-set-provision-state $ironic_id provide; 
+done
+```
+
+Simply by doing the above to bash loops the nodes were booted on a ram
+disk and every disk, including the root disk (e.g. /dev/sda), had its
+metadata removed. 
+
+Network
+-------
+
+The network is defined in [network.yaml](custom-templates/network.yaml).
+The [compute node templates](custom-templates/nic-configs/r730-osd-compute.yaml)
+use the following NICs for the following purposes:
+
+- em1 10G ceph (storage, storage_mgmt) and cloud (vxlan tenant, internal api)
+- em2 10G provisioning OSPd and undercloud control plane 
+- em3 1G provisioning foreman (only used to deploy director)
+- em4 1G link not detected
+- p4p1 10G dpdk0
+- p4p2 10G dpdk1
+
+`ovs_bridge` was not mixed with `ovs_user_bridge` for DPDK performance
+so traditional VLANs were used to isolate networks and the tenant
+network was not used in favor of using provider networks. The Ceph
+networks would be more isolated if possible. 
+
+Hyperconverged Compute Nodes
+----------------------------
+
+The following templates for Ceph and the overall layout create a
+custom role called OSDCompute: 
+
+- [ceph.yaml](custom-templates/ceph.yaml)
+- [custom-roles.yaml](custom-templates/custom-roles.yaml)
+- [layout.yaml](custom-templates/layout.yaml)
+
+The above are derived works of [templates from an HCI RA](https://github.com/RHsyseng/hci).
+Though they were modified for this envirionment and to include
+`OS::TripleO::Services::ComputeNeutronOvsDpdkAgent` in place of
+`OS::TripleO::Services::ComputeNeutronOvsAgent`. 
+
+The [nova.yaml](custom-templates/nova.yaml) contains the tunings from [nova_mem_cpu_calc.py](https://github.com/RHsyseng/hci/blob/master/scripts/nova_mem_cpu_calc.py).
+
+The [numa-systemd-osd.sh](https://github.com/RHsyseng/hci/blob/master/custom-templates/numa-systemd-osd.sh) was embedded in [post-install.yaml](custom-templates/post-install.yaml)
+so that it could co-exist with the DPDK post deployment script. 
+
+DPDK
+----
+
+The following templates were used for DPDK configuration: 
+
+- [dpdk.yaml](custom-templates/dpdk.yaml)
+- [dpdk-first-boot.yaml](custom-templates/dpdk-first-boot.yaml)
+- [post-install.yaml](custom-templates/post-install.yaml)

--- a/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/ceph.yaml
+++ b/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/ceph.yaml
@@ -1,0 +1,44 @@
+parameter_defaults:
+  ExtraConfig:
+    ceph::profile::params::fsid: eb2bb192-b1c9-11e6-9205-525400330666    
+    ceph::profile::params::osd_pool_default_pg_num: 256
+    ceph::profile::params::osd_pool_default_pgp_num: 256
+    ceph::profile::params::osd_pool_default_size: 3
+    ceph::profile::params::osd_pool_default_min_size: 2
+    ceph::profile::params::osd_recovery_max_active: 3
+    ceph::profile::params::osd_max_backfills: 1
+    ceph::profile::params::osd_recovery_op_priority: 2
+  OsdComputeExtraConfig:
+    ceph::profile::params::osds:
+        '/dev/sdb':
+          journal: '/dev/nvme0n1'
+        '/dev/sdc':
+          journal: '/dev/nvme0n1'
+        '/dev/sdd':
+          journal: '/dev/nvme0n1'
+        '/dev/sde':
+          journal: '/dev/nvme0n1'   
+        '/dev/sdf':
+          journal: '/dev/nvme0n1'
+        '/dev/sdg':
+          journal: '/dev/nvme0n1'
+        '/dev/sdh':
+          journal: '/dev/nvme0n1'
+        '/dev/sdi':
+          journal: '/dev/nvme0n1' 
+        '/dev/sdj':
+          journal: '/dev/nvme0n1'
+        '/dev/sdk':
+          journal: '/dev/nvme0n1'
+        '/dev/sdl':
+          journal: '/dev/nvme0n1'
+        '/dev/sdm':
+          journal: '/dev/nvme0n1' 
+        '/dev/sdn':
+          journal: '/dev/nvme0n1'
+        '/dev/sdo':
+          journal: '/dev/nvme0n1'
+        '/dev/sdp':
+          journal: '/dev/nvme0n1'
+        '/dev/sdq':
+          journal: '/dev/nvme0n1'

--- a/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/custom-roles.yaml
+++ b/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/custom-roles.yaml
@@ -1,0 +1,193 @@
+# Specifies which roles (groups of nodes) will be deployed
+# Note this is used as an input to the various *.j2.yaml
+# jinja2 templates, so that they are converted into *.yaml
+# during the plan creation (via a mistral action/workflow).
+#
+# The format is a list, with the following format:
+#
+# * name: (string) mandatory, name of the role, must be unique
+#
+# CountDefault: (number) optional, default number of nodes, defaults to 0
+# sets the default for the {{role.name}}Count parameter in overcloud.yaml
+#
+# HostnameFormatDefault: (string) optional default format string for hostname
+# defaults to '%stackname%-{{role.name.lower()}}-%index%'
+# sets the default for {{role.name}}HostnameFormat parameter in overcloud.yaml
+#
+# ServicesDefault: (list) optional default list of services to be deployed
+# on the role, defaults to an empty list. Sets the default for the
+# {{role.name}}Services parameter in overcloud.yaml
+
+- name: Controller
+  CountDefault: 1
+  ServicesDefault:
+    - OS::TripleO::Services::CACerts
+    - OS::TripleO::Services::CephMon
+    - OS::TripleO::Services::CephExternal
+    - OS::TripleO::Services::CephRgw
+    - OS::TripleO::Services::CinderApi
+    - OS::TripleO::Services::CinderBackup
+    - OS::TripleO::Services::CinderScheduler
+    - OS::TripleO::Services::CinderVolume
+    - OS::TripleO::Services::Core
+    - OS::TripleO::Services::Kernel
+    - OS::TripleO::Services::Keystone
+    - OS::TripleO::Services::GlanceApi
+    - OS::TripleO::Services::GlanceRegistry
+    - OS::TripleO::Services::HeatApi
+    - OS::TripleO::Services::HeatApiCfn
+    - OS::TripleO::Services::HeatApiCloudwatch
+    - OS::TripleO::Services::HeatEngine
+    - OS::TripleO::Services::MySQL
+    - OS::TripleO::Services::NeutronDhcpAgent
+    - OS::TripleO::Services::NeutronL3Agent
+    - OS::TripleO::Services::NeutronMetadataAgent
+    - OS::TripleO::Services::NeutronApi
+    - OS::TripleO::Services::NeutronCorePlugin
+    - OS::TripleO::Services::NeutronOvsAgent
+    - OS::TripleO::Services::RabbitMQ
+    - OS::TripleO::Services::HAproxy
+    - OS::TripleO::Services::Keepalived
+    - OS::TripleO::Services::Memcached
+    - OS::TripleO::Services::Pacemaker
+    - OS::TripleO::Services::Redis
+    - OS::TripleO::Services::NovaConductor
+    - OS::TripleO::Services::MongoDb
+    - OS::TripleO::Services::NovaApi
+    - OS::TripleO::Services::NovaMetadata
+    - OS::TripleO::Services::NovaScheduler
+    - OS::TripleO::Services::NovaConsoleauth
+    - OS::TripleO::Services::NovaVncProxy
+    - OS::TripleO::Services::Ntp
+    - OS::TripleO::Services::SwiftProxy
+    - OS::TripleO::Services::SwiftStorage
+    - OS::TripleO::Services::SwiftRingBuilder
+    - OS::TripleO::Services::Snmp
+    - OS::TripleO::Services::Timezone
+    - OS::TripleO::Services::CeilometerApi
+    - OS::TripleO::Services::CeilometerCollector
+    - OS::TripleO::Services::CeilometerExpirer
+    - OS::TripleO::Services::CeilometerAgentCentral
+    - OS::TripleO::Services::CeilometerAgentNotification
+    - OS::TripleO::Services::Horizon
+    - OS::TripleO::Services::GnocchiApi
+    - OS::TripleO::Services::GnocchiMetricd
+    - OS::TripleO::Services::GnocchiStatsd
+    - OS::TripleO::Services::ManilaApi
+    - OS::TripleO::Services::ManilaScheduler
+    - OS::TripleO::Services::ManilaBackendGeneric
+    - OS::TripleO::Services::ManilaBackendNetapp
+    - OS::TripleO::Services::ManilaBackendCephFs
+    - OS::TripleO::Services::ManilaShare
+    - OS::TripleO::Services::AodhApi
+    - OS::TripleO::Services::AodhEvaluator
+    - OS::TripleO::Services::AodhNotifier
+    - OS::TripleO::Services::AodhListener
+    - OS::TripleO::Services::SaharaApi
+    - OS::TripleO::Services::SaharaEngine
+    - OS::TripleO::Services::IronicApi
+    - OS::TripleO::Services::IronicConductor
+    - OS::TripleO::Services::NovaIronic
+    - OS::TripleO::Services::TripleoPackages
+    - OS::TripleO::Services::TripleoFirewall
+    - OS::TripleO::Services::OpenDaylightApi
+    - OS::TripleO::Services::OpenDaylightOvs
+    - OS::TripleO::Services::SensuClient
+    - OS::TripleO::Services::FluentdClient
+    - OS::TripleO::Services::VipHosts
+
+- name: R730Compute
+  CountDefault: 0
+  HostnameFormatDefault: '%stackname%-compute-%index%'
+  ServicesDefault:
+    - OS::TripleO::Services::CACerts
+    - OS::TripleO::Services::CephClient
+    - OS::TripleO::Services::CephExternal
+    - OS::TripleO::Services::Timezone
+    - OS::TripleO::Services::Ntp
+    - OS::TripleO::Services::Snmp
+    - OS::TripleO::Services::NovaCompute
+    - OS::TripleO::Services::NovaLibvirt
+    - OS::TripleO::Services::Kernel
+    - OS::TripleO::Services::ComputeNeutronCorePlugin
+    - OS::TripleO::Services::ComputeNeutronOvsAgent
+    - OS::TripleO::Services::ComputeCeilometerAgent
+    - OS::TripleO::Services::ComputeNeutronL3Agent
+    - OS::TripleO::Services::ComputeNeutronMetadataAgent
+    - OS::TripleO::Services::TripleoPackages
+    - OS::TripleO::Services::TripleoFirewall
+    - OS::TripleO::Services::NeutronSriovAgent
+    - OS::TripleO::Services::OpenDaylightOvs
+    - OS::TripleO::Services::SensuClient
+    - OS::TripleO::Services::FluentdClient
+    - OS::TripleO::Services::VipHosts
+
+- name: BlockStorage
+  ServicesDefault:
+    - OS::TripleO::Services::CACerts
+    - OS::TripleO::Services::BlockStorageCinderVolume
+    - OS::TripleO::Services::Kernel
+    - OS::TripleO::Services::Ntp
+    - OS::TripleO::Services::Timezone
+    - OS::TripleO::Services::Snmp
+    - OS::TripleO::Services::TripleoPackages
+    - OS::TripleO::Services::TripleoFirewall
+    - OS::TripleO::Services::SensuClient
+    - OS::TripleO::Services::FluentdClient
+    - OS::TripleO::Services::VipHosts
+
+- name: ObjectStorage
+  ServicesDefault:
+    - OS::TripleO::Services::CACerts
+    - OS::TripleO::Services::Kernel
+    - OS::TripleO::Services::Ntp
+    - OS::TripleO::Services::SwiftStorage
+    - OS::TripleO::Services::SwiftRingBuilder
+    - OS::TripleO::Services::Snmp
+    - OS::TripleO::Services::Timezone
+    - OS::TripleO::Services::TripleoPackages
+    - OS::TripleO::Services::TripleoFirewall
+    - OS::TripleO::Services::SensuClient
+    - OS::TripleO::Services::FluentdClient
+    - OS::TripleO::Services::VipHosts
+
+- name: R730CephStorage
+  ServicesDefault:
+    - OS::TripleO::Services::CACerts
+    - OS::TripleO::Services::CephOSD
+    - OS::TripleO::Services::Kernel
+    - OS::TripleO::Services::Ntp
+    - OS::TripleO::Services::Snmp
+    - OS::TripleO::Services::Timezone
+    - OS::TripleO::Services::TripleoPackages
+    - OS::TripleO::Services::TripleoFirewall
+    - OS::TripleO::Services::SensuClient
+    - OS::TripleO::Services::FluentdClient
+    - OS::TripleO::Services::VipHosts
+
+- name: OsdCompute
+  CountDefault: 0
+  HostnameFormatDefault: '%stackname%-osd-compute-%index%'
+  ServicesDefault:
+    - OS::TripleO::Services::CephOSD    
+    - OS::TripleO::Services::CACerts
+    - OS::TripleO::Services::CephClient
+    - OS::TripleO::Services::CephExternal
+    - OS::TripleO::Services::Timezone
+    - OS::TripleO::Services::Ntp
+    - OS::TripleO::Services::Snmp
+    - OS::TripleO::Services::NovaCompute
+    - OS::TripleO::Services::NovaLibvirt
+    - OS::TripleO::Services::Kernel
+    - OS::TripleO::Services::ComputeNeutronCorePlugin
+    - OS::TripleO::Services::ComputeNeutronOvsDpdkAgent
+    - OS::TripleO::Services::ComputeCeilometerAgent
+    - OS::TripleO::Services::ComputeNeutronL3Agent
+    - OS::TripleO::Services::ComputeNeutronMetadataAgent
+    - OS::TripleO::Services::TripleoPackages
+    - OS::TripleO::Services::TripleoFirewall
+    - OS::TripleO::Services::NeutronSriovAgent
+    - OS::TripleO::Services::OpenDaylightOvs
+    - OS::TripleO::Services::SensuClient
+    - OS::TripleO::Services::FluentdClient
+    - OS::TripleO::Services::VipHosts

--- a/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/dpdk-first-boot.yaml
+++ b/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/dpdk-first-boot.yaml
@@ -1,0 +1,173 @@
+heat_template_version: 2014-10-16
+
+description: >
+  This is an example showing how you can do firstboot configuration
+  of the nodes via cloud-init.  To enable this, replace the default
+  mapping of OS::TripleO::NodeUserData in ../overcloud_resource_registry*
+
+parameters:
+  ComputeKernelArgs:
+    description: >
+      Space seprated list of Kernel args to be update to grub.
+      The given args will be appended to existing args of GRUB_CMDLINE_LINUX in file /etc/default/grub
+      Example: "intel_iommu=on default_hugepagesz=1GB hugepagesz=1G hugepages=1"
+    type: string
+    default: ""
+  ComputeHostnameFormat:
+    type: string
+    default: ""
+  HostCpusList:
+    description: >
+      A list or range of physical CPU cores to be tuned.
+      The given args will be appended to the tuned cpu-partitioning profile.
+      Ex. HostCpusList: '4-12' will tune cores from 4-12
+    type: string
+    default: ""
+  NeutronDpdkCoreList:
+    description: >
+      List of logical cores for PMD threads. Its mandatory parameter.
+    type: string
+  NeutronDpdkSocketMemory:
+    description: Memory allocated for each socket
+    default: ""
+    type: string
+
+resources:
+  userdata:
+    type: OS::Heat::MultipartMime
+    properties:
+      parts:
+      - config: {get_resource: boot_config}
+      - config: {get_resource: compute_kernel_args}
+
+  boot_config:
+    type: OS::Heat::CloudConfig
+    properties:
+      cloud_config:
+        yum_repos:
+          # Overcloud images deployed without any repos.
+          # In order to install required tuned profile an activate it, we should create FDP repo.
+          rhelosp-rhel-7-fast-datapth:
+            name: Fast Datapath packages
+            baseurl: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/fast-datapath/os/
+            enabled: true
+            gpgcheck: false
+          rhel-7-common:
+            name: RHEL 7 Common
+            baseurl: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/$basearch/rh-common/os/
+            enabled: 1
+            gpgcheck: 0
+          red-hat-enterprise-linux:
+            name: Red Hat Enterprise Linux $releasever - $basearch - Server
+            baseurl: http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/
+            enabled: 1
+            gpgcheck: 0
+
+  # Verify the logs on /var/log/cloud-init.log on the overcloud node
+  compute_kernel_args:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      config:
+        str_replace:
+          template: |
+            #!/bin/bash
+            set -x
+            core_mask=''
+            get_core_mask()
+            {
+              list=$1
+              declare -a bm
+              bm=(0 0 0 0 0 0 0 0 0 0)
+              max_idx=0
+              for core in $(echo $list | sed 's/,/ /g')
+              do
+                  index=$(($core/32))
+                  temp=$((1<<$core))
+                  bm[$index]=$((${bm[$index]} | $temp))
+                  if [ $max_idx -lt $index ]; then
+                     max_idx=$index
+                  fi
+              done
+
+              printf -v core_mask "%x" "${bm[$max_idx]}"
+              for ((i=$max_idx-1;i>=0;i--));
+              do
+                  printf -v hex "%08x" "${bm[$i]}"
+                  core_mask+=$hex
+              done
+              return 0
+            }
+
+            FORMAT=$COMPUTE_HOSTNAME_FORMAT
+            if [[ -z $FORMAT ]] ; then
+              FORMAT="compute" ;
+            else
+              # Assumption: only %index% and %stackname% are the variables in Host name format
+              FORMAT=$(echo $FORMAT | sed  's/\%index\%//g' | sed 's/\%stackname\%//g') ;
+            fi
+            sed 's/SELINUX=enforcing/SELINUX=permissive/g' -i /etc/selinux/config
+            if [[ $(hostname) == *$FORMAT* ]] ; then
+              if [ -f /usr/lib/systemd/system/openvswitch-nonetwork.service ]; then
+                ovs_service_path="/usr/lib/systemd/system/openvswitch-nonetwork.service"
+              elif [ -f /usr/lib/systemd/system/ovs-vswitchd.service ]; then
+                ovs_service_path="/usr/lib/systemd/system/ovs-vswitchd.service"
+              fi
+              grep -q "RuntimeDirectoryMode=.*" $ovs_service_path
+              if [ "$?" -eq 0 ]; then
+                sed -i 's/RuntimeDirectoryMode=.*/RuntimeDirectoryMode=0775/' $ovs_service_path
+              else
+                echo "RuntimeDirectoryMode=0775" >> $ovs_service_path
+              fi
+                grep -Fxq "Group=qemu" $ovs_service_path
+              if [ ! "$?" -eq 0 ]; then
+                echo "Group=qemu" >> $ovs_service_path
+              fi
+              grep -Fxq "UMask=0002" $ovs_service_path
+              if [ ! "$?" -eq 0 ]; then
+                echo "UMask=0002" >> $ovs_service_path
+              fi
+              ovs_ctl_path='/usr/share/openvswitch/scripts/ovs-ctl'
+              grep -q "umask 0002 \&\& start_daemon \"\$OVS_VSWITCHD_PRIORITY\"" $ovs_ctl_path
+              if [ ! "$?" -eq 0 ]; then
+                sed -i 's/start_daemon \"\$OVS_VSWITCHD_PRIORITY.*/umask 0002 \&\& start_daemon \"$OVS_VSWITCHD_PRIORITY\" \"$OVS_VSWITCHD_WRAPPER\" \"$@\"/' $ovs_ctl_path
+              fi
+
+              # Install the tuned package
+              yum install -y tuned-profiles-cpu-partitioning
+
+              tuned_conf_path="/etc/tuned/cpu-partitioning-variables.conf"
+              if [ -n "$TUNED_CORES" ]; then
+                grep -q "^isolated_cores" $tuned_conf_path
+                if [ "$?" -eq 0 ]; then
+                  sed -i 's/^isolated_cores=.*/isolated_cores=$TUNED_CORES/' $tuned_conf_path
+                else
+                  echo "isolated_cores=$TUNED_CORES" >> $tuned_conf_path
+                fi
+                tuned-adm profile cpu-partitioning
+              fi
+
+              get_core_mask $PMD_CORES
+              ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-init=true
+              ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-socket-mem=$SOCKET_MEMORY
+              ovs-vsctl --no-wait set Open_vSwitch . other_config:pmd-cpu-mask=$core_mask
+              ovs-vsctl --no-wait set Open_vSwitch . other_config:dpdk-lcore-mask=0x1
+
+              sed 's/^\(GRUB_CMDLINE_LINUX=".*\)"/\1 $KERNEL_ARGS"/g' -i /etc/default/grub ;
+              grub2-mkconfig -o /etc/grub2.cfg
+
+            fi
+            reboot
+          params:
+            $KERNEL_ARGS: {get_param: ComputeKernelArgs}
+            $COMPUTE_HOSTNAME_FORMAT: {get_param: ComputeHostnameFormat}
+            $TUNED_CORES: {get_param: HostCpusList}
+            $PMD_CORES: {get_param: NeutronDpdkCoreList}
+            $SOCKET_MEMORY: {get_param: NeutronDpdkSocketMemory}
+
+outputs:
+  # This means get_resource from the parent template will get the userdata, see:
+  # http://docs.openstack.org/developer/heat/template_guide/composition.html#making-your-template-resource-more-transparent
+  # Note this is new-for-kilo, an alternative is returning a value then using
+  # get_attr in the parent template instead.
+  OS::stack_id:
+    value: {get_resource: userdata}

--- a/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/dpdk.yaml
+++ b/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/dpdk.yaml
@@ -1,0 +1,36 @@
+resource_registry:
+  # service definition for the ovs dpdk agent role 
+  # see /usr/share/openstack-tripleo-heat-templates/environments/neutron-ovs-dpdk.yaml
+  OS::TripleO::Services::ComputeNeutronOvsDpdkAgent: /usr/share/openstack-tripleo-heat-templates/puppet/services/neutron-ovs-dpdk-agent.yaml
+
+ # Add the first-boot.yaml to set the kernel parameters
+  OS::TripleO::NodeUserData: dpdk-first-boot.yaml
+  # Add the post-install.yaml file to set the DPDK arguments
+  OS::TripleO::NodeExtraConfigPost: post-install.yaml
+
+parameter_defaults:
+  # Kernel arguments for Compute node
+  ComputeKernelArgs: "intel_iommu=on iommu=pt default_hugepagesz=1GB hugepagesz=1G hugepages=12 isolcpus=1,3,5,7,9,11,13,15,17,19"
+  # Provide a list of cores that can be used as DPDK PMDs in the format - [allowed_pattern: "'[0-9,-]+'"]:
+  NeutronDpdkCoreList: "'1,3,5,7,9,11'"
+  # Provide the number of memory channels in the format - [allowed_pattern: "[0-9]+"]: 
+  NeutronDpdkMemoryChannels: "4"
+  # Set the memory allocated for each socket: 
+  NeutronDpdkSocketMemory: "'1024,1024'"
+  # Set the DPDK driver type, the default value is vfio-pci module: 
+  NeutronDpdkDriverType: "vfio-pci"
+  # Datapath type for ovs bridges
+  # see /usr/share/openstack-tripleo-heat-templates/environments/neutron-ovs-dpdk.yaml
+  NeutronDatapathType: "netdev"
+  # The vhost-user socket directory for OVS
+  # see /usr/share/openstack-tripleo-heat-templates/environments/neutron-ovs-dpdk.yaml
+  NeutronVhostuserSocketDir: "/var/run/openvswitch"
+  # Reserve the RAM for the host processes:
+  NovaReservedHostMemory: "4096"
+  # Add a list or range of physical CPU cores to be reserved for virtual machine processes: 
+  NovaVcpuPinSet: ['13,15,17,19']
+  # List the most restrictive filters first to make the filtering process for the nodes more efficient
+  NovaSchedulerDefaultFilters: "RamFilter,ComputeFilter,AvailabilityZoneFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,PciPassthroughFilter,NUMATopologyFilter"
+  # Set a list or range of physical CPU cores to be tuned: 
+  HostCpusList: '1,3,5,7,9,11,13,15,17,19'
+  # Compute/DPDK should use NUMA node 1 as per `lstopo-no-graphics`

--- a/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/layout.yaml
+++ b/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/layout.yaml
@@ -1,0 +1,6 @@
+parameter_defaults:  
+  ControllerCount: 3
+  OsdComputeCount: 6
+  OvercloudControlFlavor: control
+  OvercloudOsdComputeFlavor: compute
+  NtpServer: clock.redhat.com

--- a/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/network.yaml
+++ b/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/network.yaml
@@ -1,0 +1,46 @@
+resource_registry:
+  # ports for custom role
+  OS::TripleO::OsdCompute::Ports::TenantPort: /usr/share/openstack-tripleo-heat-templates/network/ports/tenant.yaml
+  OS::TripleO::OsdCompute::Ports::InternalApiPort: /usr/share/openstack-tripleo-heat-templates/network/ports/internal_api.yaml
+  OS::TripleO::OsdCompute::Ports::StoragePort: /usr/share/openstack-tripleo-heat-templates/network/ports/storage.yaml
+  OS::TripleO::OsdCompute::Ports::StorageMgmtPort: /usr/share/openstack-tripleo-heat-templates/network/ports/storage_mgmt.yaml
+  OS::TripleO::OsdCompute::Ports::ExternalPort: /usr/share/openstack-tripleo-heat-templates/network/ports/noop.yaml
+  # nic configs
+  OS::TripleO::Controller::Net::SoftwareConfig: /home/stack/custom-templates/nic-configs/r730-controller.yaml
+  OS::TripleO::OsdCompute::Net::SoftwareConfig: /home/stack/custom-templates/nic-configs/r730-osd-compute.yaml
+
+parameter_defaults:
+  NeutronExternalNetworkBridge: "''"
+  InternalApiNetCidr: 172.16.0.0/24
+  TenantNetCidr: 172.17.0.0/24
+  StorageNetCidr: 172.18.0.0/24
+  StorageMgmtNetCidr: 172.19.0.0/24
+  ManagementNetCidr: 172.20.0.0/24
+  ExternalNetCidr: 172.21.0.0/24
+  InternalApiAllocationPools: [{'start': '172.16.0.10', 'end': '172.16.0.200'}]
+  TenantAllocationPools: [{'start': '172.17.0.10', 'end': '172.17.0.200'}]
+  StorageAllocationPools: [{'start': '172.18.0.10', 'end': '172.18.0.200'}]
+  StorageMgmtAllocationPools: [{'start': '172.19.0.10', 'end': '172.19.0.200'}]
+  ManagementAllocationPools: [{'start': '172.20.0.10', 'end': '172.20.0.200'}]
+  ExternalAllocationPools: [{'start': '172.21.0.10', 'end': '172.21.0.100'}]
+  # Set to the router gateway on the external network
+  ExternalInterfaceDefaultRoute: 172.21.0.1
+  PublicVirtualFixedIPs: [{'ip_address':'172.21.0.10'}]
+  # Gateway router for the provisioning network (or Undercloud IP)
+  ControlPlaneDefaultRoute: 192.0.2.1
+  # The IP address of the EC2 metadata server. Generally the IP of the Undercloud
+  EC2MetadataIp: 192.0.2.1
+  # Define the DNS servers (maximum 2) for the overcloud nodes
+  DnsServers: ["10.11.5.19"]
+  InternalApiNetworkVlanID: 301
+  StorageNetworkVlanID: 302
+  StorageMgmtNetworkVlanID: 303
+  TenantNetworkVlanID: 304
+  ManagementNetworkVlanID: 305
+  ExternalNetworkVlanID: 10
+
+  NeutronTunnelTypes: 'vxlan'
+  NeutronNetworkType: 'vxlan'
+  # The OVS logical->physical bridge mappings to use.
+  NeutronBridgeMappings: 'dpdk0:br-link0,dpdk1:br-link1'
+  NeutronNetworkVLANRanges: 'dpdk0:100:200,dpdk1:100:200'  

--- a/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/nic-configs/r730-controller.yaml
+++ b/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/nic-configs/r730-controller.yaml
@@ -1,0 +1,196 @@
+heat_template_version: 2015-04-30
+
+description: >
+  Software Config to drive os-net-config to configure VLANs for the
+  compute role.
+
+parameters:
+  ControlPlaneIp:
+    default: ''
+    description: IP address/subnet on the ctlplane network
+    type: string
+  ExternalIpSubnet:
+    default: ''
+    description: IP address/subnet on the external network
+    type: string
+  InternalApiIpSubnet:
+    default: ''
+    description: IP address/subnet on the internal API network
+    type: string
+  StorageIpSubnet:
+    default: ''
+    description: IP address/subnet on the storage network
+    type: string
+  StorageMgmtIpSubnet:
+    default: ''
+    description: IP address/subnet on the storage mgmt network
+    type: string
+  TenantIpSubnet:
+    default: ''
+    description: IP address/subnet on the tenant network
+    type: string
+  ManagementIpSubnet: # Only populated when including environments/network-management.yaml
+    default: ''
+    description: IP address/subnet on the management network
+    type: string
+  ExternalNetworkVlanID:
+    default: 10
+    description: Vlan ID for the internal_api network traffic.
+    type: number
+  InternalApiNetworkVlanID:
+    default: 20
+    description: Vlan ID for the internal_api network traffic.
+    type: number
+  StorageNetworkVlanID:
+    default: 30
+    description: Vlan ID for the storage network traffic.
+    type: number
+  TenantNetworkVlanID:
+    default: 50
+    description: Vlan ID for the tenant network traffic.
+    type: number
+  ManagementNetworkVlanID:
+    default: 60
+    description: Vlan ID for the management network traffic.
+    type: number
+  StorageMgmtNetworkVlanID:
+    default: 70
+    description: Vlan ID for the storage management network traffic.
+    type: number
+  ControlPlaneSubnetCidr: # Override this via parameter_defaults
+    default: '24'
+    description: The subnet CIDR of the control plane network.
+    type: string
+  ControlPlaneDefaultRoute: # Override this via parameter_defaults
+    description: The default route of the control plane network.
+    type: string
+  ExternalInterfaceDefaultRoute: # Not used by default in this template
+    default: '10.0.0.1'
+    description: The default route of the external network.
+    type: string
+  ManagementInterfaceDefaultRoute: # Commented out by default in this template
+    default: unset
+    description: The default route of the management network.
+    type: string
+  DnsServers: # Override this via parameter_defaults
+    default: []
+    description: A list of DNS servers (2 max for some implementations) that will be added to resolv.conf.
+    type: comma_delimited_list
+  EC2MetadataIp: # Override this via parameter_defaults
+    description: The IP address of the EC2 metadata server.
+    type: string
+
+resources:
+  OsNetConfigImpl:
+    type: OS::Heat::StructuredConfig
+    properties:
+      group: os-apply-config
+      config:
+        os_net_config:
+          network_config:
+            -
+              type: interface
+              name: em1
+              use_dhcp: false
+              mtu: 9000
+            -
+              type: vlan
+              device: em1
+              mtu: 9000
+              use_dhcp: false
+              vlan_id: {get_param: StorageMgmtNetworkVlanID}
+              addresses:
+                -
+                  ip_netmask: {get_param: StorageMgmtIpSubnet}
+            -
+              type: vlan
+              device: em1
+              mtu: 9000
+              use_dhcp: false
+              vlan_id: {get_param: StorageNetworkVlanID}
+              addresses:
+                -
+                  ip_netmask: {get_param: StorageIpSubnet}
+            -
+              type: vlan
+              device: em1
+              mtu: 9000
+              use_dhcp: false
+              vlan_id: {get_param: InternalApiNetworkVlanID}
+              addresses:
+                -
+                  ip_netmask: {get_param: InternalApiIpSubnet}
+            -
+              type: vlan
+              device: em1
+              mtu: 9000
+              use_dhcp: false
+              vlan_id: {get_param: TenantNetworkVlanID}
+              addresses:
+                -
+                  ip_netmask: {get_param: TenantIpSubnet}
+            -
+              type: vlan
+              device: em1
+              mtu: 9000              
+              vlan_id: {get_param: ExternalNetworkVlanID}
+              addresses:
+                -
+                  ip_netmask: {get_param: ExternalIpSubnet}
+              routes:
+                -
+                  default: true
+                  next_hop: {get_param: ExternalInterfaceDefaultRoute}
+            -
+              type: interface
+              name: em2
+              use_dhcp: false
+              dns_servers: {get_param: DnsServers}
+              addresses:
+                -
+                  ip_netmask:
+                    list_join:
+                      - '/'
+                      - - {get_param: ControlPlaneIp}
+                        - {get_param: ControlPlaneSubnetCidr}
+              routes:
+                -
+                  ip_netmask: 169.254.169.254/32
+                  next_hop: {get_param: EC2MetadataIp}
+                -
+                  default: true
+                  next_hop: {get_param: ControlPlaneDefaultRoute}
+            -
+              # unused interface
+              type: interface
+              name: em4
+              use_dhcp: false
+              defroute: false
+            # The controller doesn't need ovs_user_bridge 
+            -
+              type: ovs_bridge
+              name: br-link0
+              use_dhcp: false
+              members:
+                -
+                  type: interface
+                  name: p4p1
+            # -
+            #   # The controller doesn't need to use this NIC or provide DPDK here
+            #   type: interface
+            #   name: p4p2
+            #   use_dhcp: false
+            #   defroute: false
+            -
+              type: ovs_bridge
+              name: br-link1
+              use_dhcp: false
+              members:
+                -
+                  type: interface
+                  name: p4p2
+
+outputs:
+  OS::stack_id:
+    description: The OsNetConfigImpl resource.
+    value: {get_resource: OsNetConfigImpl}

--- a/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/nic-configs/r730-osd-compute.yaml
+++ b/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/nic-configs/r730-osd-compute.yaml
@@ -1,0 +1,200 @@
+heat_template_version: 2015-04-30
+
+description: >
+  Software Config to drive os-net-config to configure VLANs for the
+  hyperconverged compute role (compute + osd). 
+
+parameters:
+  ControlPlaneIp:
+    default: ''
+    description: IP address/subnet on the ctlplane network
+    type: string
+  ExternalIpSubnet:
+    default: ''
+    description: IP address/subnet on the external network
+    type: string
+  InternalApiIpSubnet:
+    default: ''
+    description: IP address/subnet on the internal API network
+    type: string
+  StorageIpSubnet:
+    default: ''
+    description: IP address/subnet on the storage network
+    type: string
+  StorageMgmtIpSubnet:
+    default: ''
+    description: IP address/subnet on the storage mgmt network
+    type: string
+  TenantIpSubnet:
+    default: ''
+    description: IP address/subnet on the tenant network
+    type: string
+  ManagementIpSubnet: # Only populated when including environments/network-management.yaml
+    default: ''
+    description: IP address/subnet on the management network
+    type: string
+  InternalApiNetworkVlanID:
+    default: 20
+    description: Vlan ID for the internal_api network traffic.
+    type: number
+  StorageNetworkVlanID:
+    default: 30
+    description: Vlan ID for the storage network traffic.
+    type: number
+  StorageMgmtNetworkVlanID:
+    default: 70
+    description: Vlan ID for the storage management network traffic.
+    type: number
+  TenantNetworkVlanID:
+    default: 50
+    description: Vlan ID for the tenant network traffic.
+    type: number
+  ManagementNetworkVlanID:
+    default: 60
+    description: Vlan ID for the management network traffic.
+    type: number
+  ControlPlaneSubnetCidr: # Override this via parameter_defaults
+    default: '24'
+    description: The subnet CIDR of the control plane network.
+    type: string
+  ControlPlaneDefaultRoute: # Override this via parameter_defaults
+    description: The default route of the control plane network.
+    type: string
+  ExternalInterfaceDefaultRoute: # Not used by default in this template
+    default: '10.0.0.1'
+    description: The default route of the external network.
+    type: string
+  ManagementInterfaceDefaultRoute: # Commented out by default in this template
+    default: unset
+    description: The default route of the management network.
+    type: string
+  DnsServers: # Override this via parameter_defaults
+    default: []
+    description: A list of DNS servers (2 max for some implementations) that will be added to resolv.conf.
+    type: comma_delimited_list
+  EC2MetadataIp: # Override this via parameter_defaults
+    description: The IP address of the EC2 metadata server.
+    type: string
+
+resources:
+  OsNetConfigImpl:
+    type: OS::Heat::StructuredConfig
+    properties:
+      group: os-apply-config
+      config:
+        os_net_config:
+          network_config:
+            -
+              type: interface
+              name: em1
+              use_dhcp: false
+              mtu: 9000
+            -
+              type: vlan
+              device: em1
+              mtu: 9000
+              use_dhcp: false
+              vlan_id: {get_param: StorageMgmtNetworkVlanID}
+              addresses:
+                -
+                  ip_netmask: {get_param: StorageMgmtIpSubnet}
+            -
+              type: vlan
+              device: em1
+              mtu: 9000
+              use_dhcp: false
+              vlan_id: {get_param: StorageNetworkVlanID}
+              addresses:
+                -
+                  ip_netmask: {get_param: StorageIpSubnet}
+            -
+              type: vlan
+              device: em1
+              mtu: 9000
+              use_dhcp: false
+              vlan_id: {get_param: InternalApiNetworkVlanID}
+              addresses:
+                -
+                  ip_netmask: {get_param: InternalApiIpSubnet}
+            -
+              type: vlan
+              device: em1
+              mtu: 9000
+              use_dhcp: false
+              vlan_id: {get_param: TenantNetworkVlanID}
+              addresses:
+                -
+                  ip_netmask: {get_param: TenantIpSubnet} 
+            # compute/osd nodes do not have ExternalNetwork
+            -
+              type: interface
+              name: em2
+              use_dhcp: false
+              dns_servers: {get_param: DnsServers}
+              addresses:
+                -
+                  ip_netmask:
+                    list_join:
+                      - '/'
+                      - - {get_param: ControlPlaneIp}
+                        - {get_param: ControlPlaneSubnetCidr}
+              routes:
+                -
+                  ip_netmask: 169.254.169.254/32
+                  next_hop: {get_param: EC2MetadataIp}
+                -
+                  default: true
+                  next_hop: {get_param: ControlPlaneDefaultRoute}
+            -
+              # unused interface
+              type: interface
+              name: em4
+              use_dhcp: false
+              defroute: false
+            # -
+            #   # VLAN for VXLAN tenant networking
+            #   type: ovs_bridge
+            #   name: br-tenant
+            #   use_dhcp: false
+            #   members:
+            #     -
+            #       type: interface
+            #       name: p4p1
+            #       use_dhcp: false
+            #       # force the MAC address of the bridge to this interface
+            #       primary: true
+            #     -
+            #       type: vlan
+            #       vlan_id: {get_param: TenantNetworkVlanID}
+            #       addresses:
+            #       -
+            #         ip_netmask: {get_param: TenantIpSubnet}
+            -
+              type: ovs_user_bridge
+              name: br-link0
+              use_dhcp: false
+              members:
+                -
+                  type: ovs_dpdk_port
+                  name: dpdk0
+                  members:
+                    -
+                      type: interface
+                      name: p4p1
+            -
+              type: ovs_user_bridge
+              name: br-link1
+              use_dhcp: false
+              members:
+                -
+                  type: ovs_dpdk_port
+                  name: dpdk1
+                  members:
+                    -
+                      type: interface
+                      name: p4p2
+
+outputs:
+  OS::stack_id:
+    description: The OsNetConfigImpl resource.
+    value: {get_resource: OsNetConfigImpl}

--- a/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/nova.yaml
+++ b/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/nova.yaml
@@ -1,0 +1,7 @@
+parameter_defaults:
+  # From https://github.com/RHsyseng/hci/blob/master/scripts/nova_mem_cpu_calc.py
+  # ./nova_mem_cpu_calc.py 128 40 16 8 1.0
+  # number of guests allowed based on: vCPU 24 memory 9 (so we are memory bound)
+  ExtraConfig:
+    nova::compute::reserved_host_memory: 52500
+    nova::cpu_allocation_ratio: 0.6

--- a/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/post-install.yaml
+++ b/RDU-Scale/Newton/R730xdHciDpdk/custom-templates/post-install.yaml
@@ -1,0 +1,137 @@
+heat_template_version: 2014-10-16
+
+description: >
+  Example extra config for post-deployment
+
+parameters:
+  servers:
+    type: json
+  ComputeOvsDpdkHostnameFormat:
+    type: string
+    default: ""
+  NeutronDpdkCoreList:
+    type: string
+
+resources:
+  ExtraDeployments:
+    type: OS::Heat::StructuredDeployments
+    properties:
+      servers:  {get_param: servers}
+      config: {get_resource: ExtraConfig}
+      # Do this on CREATE/UPDATE (which is actually the default)
+      actions: ['CREATE', 'UPDATE']
+
+  ExtraConfig:
+    type: OS::Heat::SoftwareConfig
+    properties:
+      group: script
+      config:
+        str_replace:
+          template: |
+            #!/bin/bash
+            {
+            echo "Updates for Ceph"
+            # ----
+            if [[ `hostname` = *"ceph"* ]] || [[ `hostname` = *"osd-compute"* ]]; then
+                OSD_NUMA_INTERFACE=em1
+                
+                curl http://refarch.cloud.lab.eng.bos.redhat.com/pub/projects/rhos/liberty/scripts/hci/numa_rpms/install.sh | bash
+
+                # Verify the passed network interface exists 
+                if [[ ! $(ip add show $OSD_NUMA_INTERFACE) ]]; then
+                    exit 1
+                fi
+
+                # If NUMA related packages are missing, then install them
+                # If packages are baked into image, no install attempted
+                for PKG in numactl hwloc; do 
+                    if [[ ! $(rpm -q $PKG) ]]; then
+                        yum install -y $PKG
+                        if [[ ! $? ]]; then
+                            echo "Unable to install $PKG with yum"
+                            exit 1
+                        fi
+                    fi
+                done
+
+                # Find the NUMA socket of the $OSD_NUMA_INTERFACE
+                declare -A NUMASOCKET
+                while read TYPE SOCKET_NUM NIC ; do 
+                    if [[ "$TYPE" == "NUMANode" ]]; then 
+                        NUMASOCKET=$(echo $SOCKET_NUM | sed s/L//g); 
+                    fi 
+                    if [[ "$NIC" == "$OSD_NUMA_INTERFACE" ]]; then
+                        # because $NIC is the $OSD_NUMA_INTERFACE,
+                        # the NUMASOCKET has been set correctly above
+                        break # so stop looking 
+                    fi 
+                done < <(lstopo-no-graphics | tr -d [:punct:] | egrep "NUMANode|$OSD_NUMA_INTERFACE")
+
+                if [[ -z $NUMASOCKET ]]; then 
+                    echo "No NUMAnode found for $OSD_NUMA_INTERFACE. Exiting."
+                    exit 1
+                fi
+
+                UNIT='/usr/lib/systemd/system/ceph-osd@.service'
+                # Preserve the original ceph-osd start command
+                CMD=$(crudini --get $UNIT Service ExecStart)
+
+                if [[ $(echo $CMD | grep numactl) ]]; then
+                    echo "numactl already in $UNIT. No changes required."
+                    exit 0  
+                fi
+
+                # NUMA control options to append in front of $CMD
+                NUMA="/usr/bin/numactl -N $NUMASOCKET --preferred=$NUMASOCKET"
+
+                # Update the unit file to start with numactl
+                # TODO: why doesn't a copy of $UNIT in /etc/systemd/system work with numactl?
+                crudini --verbose --set $UNIT Service ExecStart "$NUMA $CMD"
+
+                # Reload so updated file is used
+                systemctl daemon-reload
+
+                # Restart OSDs with NUMA policy (print results for log)
+                OSD_IDS=$(ls /var/lib/ceph/osd | awk 'BEGIN { FS = "-" } ; { print $2 }')
+                for OSD_ID in $OSD_IDS; do
+                    echo -e "\nStatus of OSD $OSD_ID before unit file update\n"
+                    systemctl status ceph-osd@$OSD_ID 
+                    echo -e "\nRestarting OSD $OSD_ID..."
+                    systemctl restart ceph-osd@$OSD_ID
+                    echo -e "\nStatus of OSD $OSD_ID after unit file update\n"
+                    systemctl status ceph-osd@$OSD_ID
+                done
+            fi
+            # ---- 
+            echo "Updates for DPDK"
+            set -x
+            FORMAT=$COMPUTE_OVS_DPDK_HOSTNAME_FORMAT
+            if [[ -z $FORMAT ]] ; then
+              FORMAT="compute" ;
+            else
+              # Assumption: only %index% and %stackname% are the variables in Host name format
+              FORMAT=$(echo $FORMAT | sed  's/\%index\%//g' | sed 's/\%stackname\%//g') ;
+            fi
+            if [[ $(hostname) == *$FORMAT* ]] ; then
+              tuned_service=/usr/lib/systemd/system/tuned.service
+              grep -q "network.target" $tuned_service
+              if [ "$?" -eq 0 ]; then
+                sed -i '/After=.*/s/network.target//g' $tuned_service
+              fi
+              grep -q "Before=.*network.target" $tuned_service
+              if [ ! "$?" -eq 0 ]; then
+                grep -q "Before=.*" $tuned_service
+                if [ "$?" -eq 0 ]; then
+                  sed -i 's/^\(Before=.*\)/\1 network.target openvswitch.service/g' $tuned_service
+                else
+                  sed -i '/After/i Before=network.target openvswitch.service' $tuned_service
+                fi
+              fi
+
+              systemctl daemon-reload
+              systemctl restart openvswitch
+              systemctl restart neutron-openvswitch-agent
+            fi
+            }  2>&1 > /root/post_deploy_heat_output.txt
+          params:
+            $COMPUTE_OVS_DPDK_HOSTNAME_FORMAT: {get_param: ComputeOvsDpdkHostnameFormat}

--- a/RDU-Scale/Newton/R730xdHciDpdk/deploy.sh
+++ b/RDU-Scale/Newton/R730xdHciDpdk/deploy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+source ~/stackrc
+time openstack overcloud deploy --templates \
+     -r ~/custom-templates/custom-roles.yaml \
+     -e /usr/share/openstack-tripleo-heat-templates/environments/network-isolation.yaml \
+     -e /usr/share/openstack-tripleo-heat-templates/environments/puppet-pacemaker.yaml \
+     -e /usr/share/openstack-tripleo-heat-templates/environments/storage-environment.yaml \
+     -e ~/custom-templates/network.yaml \
+     -e ~/custom-templates/ceph.yaml \
+     -e ~/custom-templates/nova.yaml \
+     -e ~/custom-templates/dpdk.yaml \
+     -e ~/custom-templates/layout.yaml 

--- a/RDU-Scale/Newton/R730xdHciDpdk/undercloud/hosts
+++ b/RDU-Scale/Newton/R730xdHciDpdk/undercloud/hosts
@@ -1,0 +1,5 @@
+[undercloud]
+c10-h01-r730xd.rdu.openstack.engineering.redhat.com
+
+[hardware_store]
+# put the hwstore's fqdn here

--- a/RDU-Scale/Newton/R730xdHciDpdk/undercloud/vars/main.yml
+++ b/RDU-Scale/Newton/R730xdHciDpdk/undercloud/vars/main.yml
@@ -1,0 +1,56 @@
+---
+# All variables needed to deploy an undercloud
+
+rhos_release_rpm: https://url.corp.redhat.com/rhos-release
+
+#OSP/OSPd versioning and build
+version: 10
+rhos_release: 10-director
+build: "2017-03-03.1"
+
+# RDO
+rdo_version: newton
+rdo_rc: 3
+rdo_trunk: false
+
+deploy_additional_repos: false
+repos:
+  rhel-7-server-beta:
+    baseurl: http://walkabout.foobar.com/released/RHEL-7/7.3-Beta/Server/x86_64/os/
+
+# Scale lab boot order still broke?
+scale_lab_broke: false
+
+# bulk introspection
+introspection: true
+
+# better introspection, be sure to turn bulk off if you use this
+introspect_with_retry: false
+
+# Dump version file to this directory
+version_directory: /etc
+
+# Stack user password:
+# Make a new password:
+# python -c "from passlib.hash import sha512_crypt; print sha512_crypt.encrypt('password')"
+# stack_password: REDACTED
+
+# undercloud control plane interface:
+local_interface: em2
+
+overcloud_ssl_endpoints: false
+external_network_vip: 172.21.0.10
+
+# External private vlan on undercloud:
+deploy_external_private_vlan: true
+external_vlan_device: em2.10
+private_external_address: 172.21.0.1
+private_external_netmask: 255.255.255.0
+# Tripleo maps external network port to noop.yml, lets keep the default behavior
+allow_external_on_compute: false
+
+# neutron dns:
+dns_server: 10.11.5.19
+
+# instackenv:
+instackenv_json: http://refarch.cloud.lab.eng.bos.redhat.com/pub/projects/rhos/liberty/scripts/hci/nfv/cloud15_instackenv.json


### PR DESCRIPTION
The 10G NICs for all the R730XDs in cloud15 were physically moved so that they would be on the second NUMA node (the other NICs are on the first NUMA node). As a result of this change the NICs are presented as p4p1 instead of p6p1 (and similar).