### PR TITLE
Updating the allocation pools with a /16 cidr range.

### DIFF
--- a/RDU-Scale/Ocata/openshift-scalelab-ci/network-environment.yaml
+++ b/RDU-Scale/Ocata/openshift-scalelab-ci/network-environment.yaml
@@ -39,12 +39,12 @@ parameter_defaults:
   StorageMgmtNetCidr: 172.19.0.0/16
   ManagementNetCidr: 172.20.0.0/16
   ExternalNetCidr: 172.21.0.0/16
-  InternalApiAllocationPools: [{'start': '172.16.0.10', 'end': '172.16.0.200'}]
-  TenantAllocationPools: [{'start': '172.17.0.10', 'end': '172.17.0.200'}]
-  StorageAllocationPools: [{'start': '172.18.0.10', 'end': '172.18.0.200'}]
-  StorageMgmtAllocationPools: [{'start': '172.19.0.10', 'end': '172.19.0.200'}]
-  ManagementAllocationPools: [{'start': '172.20.0.10', 'end': '172.20.0.200'}]
-  ExternalAllocationPools: [{'start': '172.21.0.10', 'end': '172.21.0.100'}]
+  InternalApiAllocationPools: [{'start': '172.16.0.3', 'end': '172.16.255.254'}]
+  TenantAllocationPools: [{'start': '172.17.0.3', 'end': '172.17.255.254'}]
+  StorageAllocationPools: [{'start': '172.18.0.3', 'end': '172.18.255.254'}]
+  StorageMgmtAllocationPools: [{'start': '172.19.0.3', 'end': '172.19.255.254'}]
+  ManagementAllocationPools: [{'start': '172.20.0.3', 'end': '172.20.255.254'}]
+  ExternalAllocationPools: [{'start': '172.21.0.3', 'end': '172.21.255.254'}]
   # Set to the router gateway on the external network
   ExternalInterfaceDefaultRoute: 172.21.0.1
   PublicVirtualFixedIPs: [{'ip_address':'172.21.0.2'}]


### PR DESCRIPTION
The cidr was expanded to /16 on all the networks but the allocation pools were never expanded.

This PR addresses my review comments from https://github.com/redhat-performance/openstack-templates/pull/14 regarding the network allocation pools and the /16 cidr ranages with this PR.