### PR TITLE
Changing the size of the ceph pg and pgp in the template.

### DIFF
--- a/RDU-Scale/Ocata/openshift-scalelab-ci/1029u-storage-environment.yaml
+++ b/RDU-Scale/Ocata/openshift-scalelab-ci/1029u-storage-environment.yaml
@@ -26,8 +26,8 @@ parameter_defaults:
   #GnocchiBackend: rbd
   ExtraConfig:
     #ceph::profile::params::fsid: eb2bb192-b1c9-11e6-9205-525400330667
-    ceph::profile::params::osd_pool_default_pg_num: 256
-    ceph::profile::params::osd_pool_default_pgp_num: 256
+    ceph::profile::params::osd_pool_default_pg_num: 666
+    ceph::profile::params::osd_pool_default_pgp_num: 666
     ceph::profile::params::osd_pool_default_size: 3
     ceph::profile::params::osd_pool_default_min_size: 2
     ceph::profile::params::osd_recovery_max_active: 1


### PR DESCRIPTION
I was informed that these sizes were incorrect. I do not know very much about Ceph but I understand we have 5 SuperMicro 1029u systems and the sizes should have been larger. @jeremyeder ran a calculator and came up with a number of 666. Please tell me if any of the other variables need to change as well.

@ekuric @bengland2 PTAL