### PR TITLE
Changing 1029pcompute to compute for browbeat.

### DIFF
--- a/RDU-Scale/Ocata/openshift-scalelab-ci/deploy.yaml
+++ b/RDU-Scale/Ocata/openshift-scalelab-ci/deploy.yaml
@@ -15,4 +15,4 @@ parameter_defaults:
   R620ComputeSchedulerHints:
     'capabilities:node': 'r620compute-%index%'
   P1029ComputeSchedulerHints:
-    'capabilities:node': '1029pcompute-%index%'
+    'capabilities:node': 'compute-%index%'

--- a/RDU-Scale/Ocata/openshift-scalelab-ci/roles_data.yaml
+++ b/RDU-Scale/Ocata/openshift-scalelab-ci/roles_data.yaml
@@ -219,7 +219,7 @@
 
 - name: P1029Compute
   CountDefault: 0
-  HostnameFormatDefault: '%stackname%-1029pcompute-%index%'
+  HostnameFormatDefault: '%stackname%-compute-%index%'
   disable_upgrade_deployment: True
   ServicesDefault:
     - OS::TripleO::Services::CACerts

--- a/RDU-Scale/Ocata/openshift-scalelab-ci/scheduler-hints.yaml
+++ b/RDU-Scale/Ocata/openshift-scalelab-ci/scheduler-hints.yaml
@@ -8,6 +8,6 @@ parameter_defaults:
   R620ComputeSchedulerHints:
     'capabilities:node': 'r620compute-%index%'
   P1029ComputeSchedulerHints:
-    'capabilities:node': '1029pcompute-%index%'
+    'capabilities:node': 'compute-%index%'
   CephStorageSchedulerHints:
     'capabilities:node': 'cephstorage-%index%'


### PR DESCRIPTION
This is a change is based on a comment in openshift-deploy.yml 
`# as mapped in roles data under HostnameFormatDefault will have -# appended to lock hosts to machines`
Where the pin value changed from 1029pcompute to compute

I am concerned this might not pickup the right template for 1029p systems. That is still unclear to me.