### PR TITLE
Fix indention issue

### DIFF
--- a/RDU-Scale/Ocata/openshift-scalelab-ci/1029u-storage-environment.yaml
+++ b/RDU-Scale/Ocata/openshift-scalelab-ci/1029u-storage-environment.yaml
@@ -34,10 +34,10 @@ parameter_defaults:
     ceph::profile::params::osd_max_backfills: 1
     ceph::profile::params::osd_recovery_op_priority: 1
     #ceph::profile::params::osd_journal_size: 10240
-  CephPools:
-    vms:
-      pg_num: 1024
-      pgp_num: 1024
+    CephPools:
+      vms:
+        pg_num: 1024
+        pgp_num: 1024
   CephStorageExtraConfig:
     ceph::profile::params::osds:
       '/dev/nvme0n1':


### PR DESCRIPTION
Looking at the documentation [1], it seems we needed to indent this.

[1] https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/11/html-single/red_hat_ceph_storage_for_the_overcloud/index#custom-ceph-pools