### PR TITLE
The External..DefaultRoute must not be in the allocation pool.

### DIFF
--- a/RDU-Scale/Ocata/openshift-scalelab-staging/network-environment.yaml
+++ b/RDU-Scale/Ocata/openshift-scalelab-staging/network-environment.yaml
@@ -21,11 +21,11 @@ parameter_defaults:
   StorageMgmtAllocationPools: [{'start': '172.19.0.3', 'end': '172.19.255.254'}]
   ManagementAllocationPools: [{'start': '172.20.0.3', 'end': '172.20.255.254'}]
   # ExternalAllocationPools: [{'start': '172.21.0.3', 'end': '172.21.0.99'}]
-  ExternalAllocationPools: [{'start': '10.12.95.193', 'end': '10.12.95.199'}]
+  ExternalAllocationPools: [{'start': '10.12.95.194', 'end': '10.12.95.199'}]
   # Set to the router gateway on the external network
-  ExternalInterfaceDefaultRoute: 10.12.95.193
+  ExternalInterfaceDefaultRoute: 10.12.95.254
   #PublicVirtualFixedIPs: [{'ip_address':'172.21.0.2'}]
-  PublicVirtualFixedIPs: [{'ip_address':'10.12.95.194'}]
+  PublicVirtualFixedIPs: [{'ip_address':'10.12.95.193'}]
   # Gateway router for the provisioning network (or Undercloud IP)
   ControlPlaneDefaultRoute: 192.0.2.1
   # The IP address of the EC2 metadata server. Generally the IP of the Undercloud


### PR DESCRIPTION
The ExternalInterfaceDefaultRoute (gateway) must be outside the ExternalAllocationPools