### PR TITLE
Define the storage management network.

### DIFF
--- a/RDU-Scale/Ocata/openshift-scalelab-staging/nic-configs/1029p-cephstorage.yaml
+++ b/RDU-Scale/Ocata/openshift-scalelab-staging/nic-configs/1029p-cephstorage.yaml
@@ -107,6 +107,12 @@ resources:
                   addresses:
                     -
                       ip_netmask: {get_param: StorageIpSubnet}
+                -
+                  type: vlan
+                  vlan_id: {get_param: StorageMgmtNetworkVlanID}
+                  addresses:
+                    -
+                      ip_netmask: {get_param: StorageMgmtIpSubnet}
             -
               type: ovs_bridge
               name: br-tenant
@@ -151,21 +157,6 @@ resources:
                   addresses:
                     -
                       ip_netmask: {get_param: InternalApiIpSubnet}
-
-            # -
-            #   type: ovs_bridge
-            #   name: br-management
-            #   members:
-            #     -
-            #       type: interface
-            #       name: enp216s0f1 # not an vaild adapter name for 1029p
-            #       primary: true
-            #     -
-            #       type: vlan
-            #       vlan_id: {get_param: StorageMgmtNetworkVlanID}
-            #       addresses:
-            #         -
-            #           ip_netmask: {get_param: StorageMgmtIpSubnet}
 
 
 outputs:


### PR DESCRIPTION
The storage management network must be defined on the ceph template. Can not use nic4 (enp94s0f3) in this case because that is attached to a different switch that only allows VLAN 520 and 620 traffic. 