### PR TITLE
Configuring the other group pg_num to avoid warning in staging env.

### DIFF
--- a/RDU-Scale/Ocata/openshift-scalelab-staging/1029p-storage-environment.yaml
+++ b/RDU-Scale/Ocata/openshift-scalelab-staging/1029p-storage-environment.yaml
@@ -35,9 +35,25 @@ parameter_defaults:
     ceph::profile::params::osd_recovery_op_priority: 1
     #ceph::profile::params::osd_journal_size: 10240
   CephPools:
+    rbd:
+      pg_num: 8
+    backup:
+      pg_num: 8
+    images:
+      pg_num: 64
+      pgp_num: 64
+    manilla_:
+      pg_num: 8
+    manila_:
+      pg_num: 8
+    metrics:
+      pg_num: 8
     vms:
       pg_num: 64
       pgp_num: 64
+    volume:
+      pg_num: 8
+
   CephStorageExtraConfig:
     ceph::profile::params::osds:
       '/dev/nvme0n1':


### PR DESCRIPTION
The staging environment deployed with only 3 ceph nodes on the 1029p systems which only have 1 nvme disk. The ceph status was HEALTH_WARN too many PGs per OSD (896 > max 300)

In the config we only set the vms group pg_num and pgp_num and the rest seem to be defaulted to values that are too high.  

I spent some time with the pg calculator and came up with this:
![staging_pg_calculator](https://user-images.githubusercontent.com/6385185/38963482-d284a51c-4337-11e8-9e0d-7ba98783828a.png)

So I am going to set the other groups to lower values to avoid the warning and set the PGs according to this value.

@akrzos or @ekuric PTAL