### PR TITLE
Updating the 1029u ceph pool list with values from calculator.

### DIFF
--- a/RDU-Scale/Ocata/openshift-scalelab-ci/1029u-storage-environment.yaml
+++ b/RDU-Scale/Ocata/openshift-scalelab-ci/1029u-storage-environment.yaml
@@ -25,20 +25,38 @@ parameter_defaults:
   ## Gnocchi backend can be either 'rbd' (Ceph), 'swift' or 'file'.
   #GnocchiBackend: rbd
   ExtraConfig:
-    #ceph::profile::params::fsid: eb2bb192-b1c9-11e6-9205-525400330667
-    #ceph::profile::params::osd_pool_default_pg_num: 256
-    #ceph::profile::params::osd_pool_default_pgp_num: 256
     ceph::profile::params::osd_pool_default_size: 3
     ceph::profile::params::osd_pool_default_min_size: 2
     ceph::profile::params::osd_recovery_max_active: 1
     ceph::profile::params::osd_max_backfills: 1
     ceph::profile::params::osd_recovery_op_priority: 1
-    #ceph::profile::params::osd_journal_size: 10240
+  # OpenStack Ocata creates 8 ceph osd pools:
+  # rbd, backups, images, manila_data, manila_metadata, metrics, vms, volumes
   CephPools:
+    # Can not change rdb group.
+    backups:
+      pg_num: 64
+      pgp_num: 64
+    images:
+      pg_num: 512
+      pgp_num: 512
+    manila_data:
+      pg_num: 64
+      pgp_num: 64
+    manila_metadata:
+      pg_num: 64
+      pgp_num: 64
+    metrics:
+      pg_num: 64
+      pgp_num: 64
     vms:
-      pg_num: 1024
-      pgp_num: 1024
+      pg_num: 512
+      pgp_num: 512
+    volumes:
+      pg_num: 64
+      pgp_num: 64
   CephStorageExtraConfig:
+    # There are 4 OSDs per 1029u.
     ceph::profile::params::osds:
       '/dev/nvme0n1':
         journal: '/dev/nvme0n1'


### PR DESCRIPTION
OpenStack Ocata creates 8 ceph pools by default. Previously we only modified one pool Placement Group (pg) number. This caused a HEALTH_WARN at first but as soon as we put data in ceph, the warning went away. This PR aims to avoid the HEALTH_WARN from the start by using the calculator and adjusting the pg_num for the other groups.

Each 1029u has 4 OSDs, and there are currently 5 1029u systems (4*5=20 OSDs) in the scale-ci cloud03 environment.
![scale-ci_5x1029u_ceph_pg_calc](https://user-images.githubusercontent.com/6385185/39001773-b36d15f8-43bc-11e8-8665-0974ac2ee6cd.png)

After the core OpenShift cluster is installed I ran `rados df` to show the usage of the pools. It seems we only have data in the "images" and "vms" pool and the previous configuration was only adjusting the "vms" pool pg_num.
```
[root@overcloud-cephstorage-0 heat-admin]# rados df
pool name                 KB      objects       clones     degraded      unfound           rd        rd KB           wr        wr KB
backups                    0            0            0            0            0            0            0            0            0
images             121634824        14857            0            0            0      6277172   1389038991       609180    730161731
manila_data                0            0            0            0            0            0            0            0            0
manila_metadata            0            0            0            0            0            0            0            0            0
metrics                    0            0            0            0            0            0            0            0            0
rbd                        0            0            0            0            0            0            0            0            0
vms                 72386031        17822            0            0            0     15752610     23237163     14595864   1482729420
volumes                    0            0            0            0            0            0            0            0            0
  total used       586197880        32679
  total avail    46170389880
  total space    46756587760
```

So adding more pg_num for the images pool as well in this PR.