### PR TITLE
Using the correct names for the ceph pools. 

### DIFF
--- a/RDU-Scale/Ocata/openshift-scalelab-staging/1029p-storage-environment.yaml
+++ b/RDU-Scale/Ocata/openshift-scalelab-staging/1029p-storage-environment.yaml
@@ -33,18 +33,19 @@ parameter_defaults:
     ceph::profile::params::osd_recovery_max_active: 1
     ceph::profile::params::osd_max_backfills: 1
     ceph::profile::params::osd_recovery_op_priority: 1
-    #ceph::profile::params::osd_journal_size: 10240
+  # OpenStack Ocata creates 8 ceph osd pools:
+  # rbd, backups, images, manila_data, manila_metadata, metrics, vms, volumes
   CephPools:
-    backup:
+    backups:
       pg_num: 8
       pgp_num: 8
     images:
       pg_num: 64
       pgp_num: 64
-    manilla_:
+    manila_data:
       pg_num: 8
       pgp_num: 8
-    manila_:
+    manila_metadata:
       pg_num: 8
       pgp_num: 8
     metrics:
@@ -53,11 +54,12 @@ parameter_defaults:
     vms:
       pg_num: 64
       pgp_num: 64
-    volume:
+    volumes:
       pg_num: 8
       pgp_num: 8
 
   CephStorageExtraConfig:
+    # Just one OSD per 1029p.
     ceph::profile::params::osds:
       '/dev/nvme0n1':
         journal: '/dev/nvme0n1'


### PR DESCRIPTION
On the last ceph PR I used the calculator and the pool name field is not long enough to show all the text. So I created some pools with different names. This PR addresses this error. I manually created the pools with these sizes and see HEALTH_OK message in the staging environment.

There are only 3 OSDs in the staging (cloud05) environment so these values are different than the "regular" scale-ci environment (cloud03).
